### PR TITLE
Add exported class

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -108,6 +108,7 @@ async function prepareDoc() {
       node.attributes.src.value = node.src
     }
   }
+  html.classList.add("kef-doc-exported");
   html.appendChild(head)
   html.appendChild(body)
   body.appendChild(rootDiv)


### PR DESCRIPTION
Theme developers can adjust styles for exported version of pages.
B'cose just using existing `.kef-doc` (`<div id="app-container" class="kef-doc">` ) also applied in preview can broke them theme.